### PR TITLE
Add Signet to Social section

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,10 +601,10 @@ and more.
 - **[OAK](https://oak.community)**: OAK is a community currency for the People
   of Oakland.
 
-- **[Signet](https://signet.sebayaki.com)**: Signet is an onchain signature
-  platform on Base where users and AI agents can sign URLs onchain. Features
-  spotlight ads purchasable via USDC using the x402 payment protocol, with an
-  open-source CLI for agent integration.
+- **[Signet](https://signet.sebayaki.com)**: Signet is an onchain advertising
+  platform on Base where users and AI agents can purchase spotlight ads with
+  USDC using the x402 payment protocol. Open-source CLI available for agent
+  integration.
 
 - **[Tally](https://www.tally.xyz)**: Tally powers the largest DAOs in the
   Ethereum ecosystem. With Tally, you can decentralize your Protocol, project,

--- a/README.md
+++ b/README.md
@@ -601,6 +601,11 @@ and more.
 - **[OAK](https://oak.community)**: OAK is a community currency for the People
   of Oakland.
 
+- **[Signet](https://signet.sebayaki.com)**: Signet is an onchain signature
+  platform on Base where users and AI agents can sign URLs onchain. Features
+  spotlight ads purchasable via USDC using the x402 payment protocol, with an
+  open-source CLI for agent integration.
+
 - **[Tally](https://www.tally.xyz)**: Tally powers the largest DAOs in the
   Ethereum ecosystem. With Tally, you can decentralize your Protocol, project,
   L2 and more. Build on Tally for a robust decentralized ecosystem of tooling.


### PR DESCRIPTION
**[Signet](https://signet.sebayaki.com)** — An onchain signature platform on Base where users and AI agents can sign URLs onchain. Features spotlight ads purchasable via USDC using the x402 payment protocol.

- Website: https://signet.sebayaki.com
- CLI: [`@signet-base/cli`](https://www.npmjs.com/package/@signet-base/cli)
- Contracts on Base mainnet
- [Dune Dashboard](https://dune.com/sebayaki/signet)