### PR TITLE
Add LaT-PFN Signals to DeFi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ and more.
   gas fees with it's autocompounding feature. See the best yields that DeFi has
   to offer, set your crypto to work and let Harvest handle the rest!
 
+- **[LaT-PFN Signals](https://frontend-pi-fawn-4b09ub6edt.vercel.app)**: AI-powered
+  futures trading signals verified on-chain. Uses LaT-PFN zero-shot time-series
+  forecasting for micro futures (MNQ, MYM, MES, MBT). Every forecast is hashed
+  and posted to Base L2 before delivery, eliminating hindsight bias.
+
 - **[Maverick Protocol](https://app.mav.xyz/pools)**: Maverick Protocol is
   eliminating inefficiency from DeFi by helping users put liquidity where it can
   do the most work. Backed by Founders Fund, Pantera Capital, Coinbase Ventures,

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ and more.
   gas fees with it's autocompounding feature. See the best yields that DeFi has
   to offer, set your crypto to work and let Harvest handle the rest!
 
-- **[LaT-PFN Signals](https://frontend-pi-fawn-4b09ub6edt.vercel.app)**: AI-powered
+- **[LaT-PFN Signals](https://latpfn.xyz)**: AI-powered
   futures trading signals verified on-chain. Uses LaT-PFN zero-shot time-series
   forecasting for micro futures (MNQ, MYM, MES, MBT). Every forecast is hashed
   and posted to Base L2 before delivery, eliminating hindsight bias.


### PR DESCRIPTION
## Summary
- Adds **LaT-PFN Signals** to the DeFi section (alphabetical order)
- AI-powered futures trading signals with on-chain forecast verification on Base L2
- Uses LaT-PFN zero-shot time-series forecasting for micro futures (MNQ, MYM, MES, MBT)
- Every forecast is hashed and posted to Base before delivery — eliminates hindsight bias

## Details
- **Contract:** [0x901c...1091](https://basescan.org/address/0x901c169aa21a9eC593c52bc6F0eaA814eDf41091)
- **Live since:** February 2026
- **Performance:** 187 trades, 56.7% win rate, 1.61 profit factor, +$3,205 P&L (broker-confirmed)
- **Stack:** Solidity smart contract on Base L2, Next.js frontend with Privy auth