### PR TITLE
Add MainStreet — reputation oracle for onchain AI agents on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ and more.
   better understand users, increase engagement, improve retention and drive
   growth.
 
+- **[MainStreet](https://avisradar-production.up.railway.app/mainstreet.html)**: Reputation oracle for onchain AI agents and ERC-20 tokens on Base. Returns BLOCK/CAUTION/PROCEED trust verdicts in <100ms via REST + MCP. Covers Virtuals agents, Clanker tokens, DEX launches (Aerodrome / UniswapV3 / BaseSwap), sniper detection, allowlist + denylist, wallet cluster analysis. EIP-712 signed verdicts, ERC-8004 registered.
+
 - **[Mnemonic](https://www.mnemonichq.com/)**: Build exceptional Web3
   experiences faster with Mnemonic – the NFT data, analytics, and insights
   provider for builders, brands, and enterprises creating in Web3.


### PR DESCRIPTION
Adding [MainStreet](https://avisradar-production.up.railway.app/mainstreet.html), a reputation oracle for onchain AI agents and ERC-20 tokens on Base.

**What it does**
- Trust verdicts in <100ms : BLOCK / CAUTION / PROCEED for any Base wallet or token
- Covers Virtuals agents, Clanker tokens, DEX launches (Aerodrome / UniswapV3 / BaseSwap), DexScreener trending
- Sniper detection, allowlist + denylist, wallet cluster analysis (Bubblemaps-style spider web)
- EIP-712 signed verdicts, ERC-8004 registered (agentId 53953)
- Native MCP server (`@raskhaaa/mainstreet-oracle`) + agentskills.io skill + Base MCP plugin
- x402 USDC paywall on premium endpoints

**Why Base ecosystem**
The Base agent economy is growing fast (16k+ Virtuals agents). MainStreet adds a missing trust layer before agent-to-agent payments — agents call `/preflight/{address}` before signing any transaction.

**Format**
Single entry alphabetically inserted in the Infrastructure section.

Free + open. ERC-8004 registry. ERC-712 signatures. No closed dependencies.