### PR TITLE
Add sunwatch to Base infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,10 @@ and more.
   subscriptions, salaries, vesting, and rewards to DAOs and crypto-native
   businesses worldwide.
 
+- **[sunwatch](https://sunwatch.sunfamily.xyz)**: Crypto-paid uptime monitoring
+  for side projects. Add a URL and webhook, send the exact USDC amount on Base,
+  and the monitor auto-activates. No accounts, no KYC, no monthly subscription.
+
 - **[Syndicate](https://syndicate.io/)**: Syndicate is a platform that allows
   customers to create communities, products, and experiences onchain at
   enterprise scale.


### PR DESCRIPTION
**sunwatch** is a crypto-paid uptime monitor for side projects.\n\n- Pay per monitor with USDC on Base\n- No accounts, no KYC, no subscription lock-in\n- Webhook alerts on down/up state changes\n\nURL: https://sunwatch.sunfamily.xyz\nRepo: https://github.com/ryan-knowone/sunwatch\n\nAdded to the Infrastructure section alphabetically.